### PR TITLE
updates before the pre-keyboard_shortcuts-ng commits for RC 0.9 and 1.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,14 @@
-keyboard_shortcuts
-==================
+# keyboard_shortcuts
 
-keyboard_shortcuts allows some functionality to be handled with the keyboard. It adds an icon to the mail screen to view all available shortcuts. 
 
-OLD VERSIONS
-------------
+This is a deadend fork of original
+[keyboard_shortcuts](https://github.com/corbosman/keyboard_shortcuts) Roundcube
+plugin repository.
 
-This project has moved from Google Code to git. Older version are available at [Google Code](http://code.google.com/p/roundcube-plugins/downloads/list). This git repository is only for roundcube versions 0.8 and higher.
+Main intention of this fork was to pick up all unmerged but valid changes across
+GitHub before starting with development of next-gen plugin.
 
-CONTACT
--------
-Author:   Cor Bosman (cor@roundcu.be)
-
-Bug reports through github (https://github.com/corbosman/keyboard_shortcuts/issues)
-
-LICENSE
--------
-
-This plugin is distributed under the GNU General Public License Version 2.
-Please read through the file LICENSE for more information about this license.
+Next Generation plugin
+[Keyboard Shortcuts NG](https://github.com/teonsystems/roundcube-plugin-keyboard-shortcuts-ng)
+can be found [here (code)](https://github.com/teonsystems/roundcube-plugin-keyboard-shortcuts-ng)
+and [here (releases)](https://plugins.roundcube.net/packages/teon/keyboard_shortcuts_ng).

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
   "support": {
           "email": "cor@roundcu.be",
           "issues": "https://github.com/corbosman/keyboard_shortcuts/issues"
-      }
+      },
+    "require": {
+        "roundcube/plugin-installer": ">=0.1.3"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":"cor/keyboard_shortcuts",
+  "name":"dapphp/keyboard_shortcuts",
   "description":"allows some functionality to be handled with the keyboard",
   "license":"GPL-2.0",
   "homepage":"https://github.com/corbosman/keyboard_shortcuts",
@@ -17,6 +17,6 @@
           "issues": "https://github.com/corbosman/keyboard_shortcuts/issues"
       },
     "require": {
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": ">=0.1.7"
     }
 }

--- a/keyboard_shortcuts.js
+++ b/keyboard_shortcuts.js
@@ -94,6 +94,9 @@ $(function() {
           $('#quicksearchbox').focus();
           $('#quicksearchbox').select();
           return false;
+        case 116:		// t = togglepreview
+          $('#mailpreviewtoggle')[0].click();
+          return false;
         case 117:		// u = update (check for mail)
           rcmail.command('checkmail');
           return false;

--- a/keyboard_shortcuts.js
+++ b/keyboard_shortcuts.js
@@ -19,6 +19,16 @@ $(function() {
     return key_pressed(e);
   });
 
+  // special case. If we hit ctrl-enter, and we're composing, and we have focus (in the HTML editor iframe), then send email
+  // Limitation is that it adds in a line from hitting enter, which is something tinymce seems to do.
+  $(window.setTimeout(function() {
+    $('#composebody_ifr').contents().keydown(function (e) {
+      if (rcmail.env.action == 'compose' && e.which == 13 && e.ctrlKey) {
+        $('.button.send').click();
+        return false;
+      }
+    });
+  }, 1000));
 
   function key_pressed (e) {
     // special case. If we hit ctrl-enter, and we're composing, and we have focus, then send email

--- a/keyboard_shortcuts.js
+++ b/keyboard_shortcuts.js
@@ -22,7 +22,7 @@ $(function() {
 
   function key_pressed (e) {
     // special case. If we hit ctrl-enter, and we're composing, and we have focus, then send email
-    if (rcmail.env.action == 'compose' && e.which == 13 && e.ctrlKey && $("*:focus").is("#composebody")) {
+    if (rcmail.env.action == 'compose' && (e.which == 13 || e.which == 10) && e.ctrlKey && $("*:focus").is("#composebody")) {
       $('.button.send').click();
       return false;
     }

--- a/keyboard_shortcuts.js
+++ b/keyboard_shortcuts.js
@@ -82,6 +82,19 @@ $(function() {
         case 107:		// k = next page (similar to Gmail)
           rcmail.command('nextpage');
           return false;
+        case 109:		// m = mark read/unread (similar to Thunderbird)
+          var uid = rcmail.message_list.get_selection();
+          if (uid && uid.length > 0) {
+            var mid = rcmail.message_list.rows[uid[0]].id;
+            if ($('tr#' + mid).hasClass('unread')) {
+              rcmail.command('mark', 'read');
+            } else {
+              rcmail.command('mark', 'unread');
+            }
+          } else {
+            return true;
+          }
+          return false;
         case 112:		// p = print
           if (rcmail.message_list.selection.length == 1)
           rcmail.command('print');

--- a/keyboard_shortcuts.php
+++ b/keyboard_shortcuts.php
@@ -90,6 +90,7 @@ class keyboard_shortcuts extends rcube_plugin
         $c .= "<div class='shortcut_key'>r</div> ".$this->gettext('replytomessage')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>R</div> ".$this->gettext('replytoallmessage')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>s</div> ".$this->gettext('quicksearch')."<br class='clear' />";
+        $c .= "<div class='shortcut_key'>t</div> ".$this->gettext('mailpreviewtoggle')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>u</div> ".$this->gettext('checkmail')."<br class='clear' />";
         $c .= "<div class='shortcut_key'> </div> <br class='clear' />";
         $c .= "</div>";

--- a/keyboard_shortcuts.php
+++ b/keyboard_shortcuts.php
@@ -22,6 +22,7 @@
  * f:	Forward message
  * j:	Go to previous page of messages (as Gmail)
  * k:	Go to next page of messages (as Gmail)
+ * m:	Mark message(s) read/unread (as Thunderbird)
  * p:	Print message
  * r:	Reply to message
  * R:	Reply to all of message
@@ -81,6 +82,7 @@ class keyboard_shortcuts extends rcube_plugin
         $c .= "<div class='shortcut_key'>?</div> ".$this->gettext('help')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>a</div> ".$this->gettext('selectallvisiblemessages')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>A</div> ".$this->gettext('markallvisiblemessagesasread')."<br class='clear' />";
+        $c .= "<div class='shortcut_key'>m</div> ".$this->gettext('markselected')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>c</div> ".$this->gettext('compose')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>d</div> ".$this->gettext('deletemessage')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>f</div> ".$this->gettext('forwardmessage')."<br class='clear' />";

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -6,6 +6,7 @@ $labels['show'] = 'Show';
 $labels['help'] = 'Help';
 $labels['selectallvisiblemessages'] = 'Select all visible messages';
 $labels['markallvisiblemessagesasread'] = 'Mark all visible messages as read';
+$labels['markselected'] = 'Mark selected message(s) as read or unread';
 $labels['title'] = 'Shortcuts';
 
 ?>


### PR DESCRIPTION
this pull grab from teonsystem those changes:

* add also "numeric enter" apart of "enter" key supported as "Update keyboard_shortcuts.js" from https://github.com/teonsystems/roundcube-plugin-keyboard-shortcuts-legacy/commit/20228ed470b8cfc82c5ebf324850e6846d276b8a that are equal to https://github.com/gloony/rc_keyboard_shortcuts/commit/f14ecba115892a41993b975815845e325cf8430f as task issue #2 
*  m:	Mark message(s) read/unread (as Thunderbird) from https://github.com/teonsystems/roundcube-plugin-keyboard-shortcuts-legacy/commit/3f82f9e47113b560f4a41689b96b35eb2233f279 of dapphp
* Update to work with HTML editor  : send email if we hot contrl+enter currently only with main enter from https://github.com/teonsystems/roundcube-plugin-keyboard-shortcuts-legacy/commit/fc6a2166b1e79a115206654383258149460323dd of github-amovitz/patch-1
* Toggle mail preview with 't'  from https://github.com/teonsystems/roundcube-plugin-keyboard-shortcuts-legacy/commit/7b231367936d7e3288f51e755277303c6facf653  of github-dscho/dscho
